### PR TITLE
Generate the SHA512 hash of a superuser's password within Terraform

### DIFF
--- a/aws/bootstrap.tf
+++ b/aws/bootstrap.tf
@@ -4,9 +4,9 @@ resource "aws_instance" "bootstrap" {
   # communicate with the resource (instance)
   connection {
     # The default username for our AMI
-    user = "${module.aws-tested-oses.user}"
+    user        = "${module.aws-tested-oses.user}"
     private_key = "${local.private_key}"
-    agent = "${local.agent}"
+    agent       = "${local.agent}"
 
     # The connection will use the local SSH agent for authentication.
   }
@@ -18,10 +18,10 @@ resource "aws_instance" "bootstrap" {
   instance_type = "${var.aws_bootstrap_instance_type}"
 
   tags {
-   owner = "${coalesce(var.owner, data.external.whoami.result["owner"])}"
-   expiration = "${var.expiration}"
-   Name = "${data.template_file.cluster-name.rendered}-bootstrap"
-   cluster = "${data.template_file.cluster-name.rendered}"
+    owner      = "${coalesce(var.owner, data.external.whoami.result["owner"])}"
+    expiration = "${var.expiration}"
+    Name       = "${data.template_file.cluster-name.rendered}-bootstrap"
+    cluster    = "${data.template_file.cluster-name.rendered}"
   }
 
   # Lookup the correct AMI based on the region
@@ -34,7 +34,6 @@ resource "aws_instance" "bootstrap" {
   # Our Security group to allow http, SSH, and outbound internet access only for pulling containers from the web
   vpc_security_group_ids = ["${aws_security_group.any_access_internal.id}", "${aws_security_group.ssh.id}", "${aws_security_group.internet-outbound.id}"]
 
-
   # We're going to launch into the same subnet as our ELB. In a production
   # environment it's more common to have a separate private subnet for
   # backend instances.
@@ -42,14 +41,14 @@ resource "aws_instance" "bootstrap" {
 
   # OS init script
   provisioner "file" {
-   content = "${module.aws-tested-oses.os-setup}"
-   destination = "/tmp/os-setup.sh"
-   }
+    content     = "${module.aws-tested-oses.os-setup}"
+    destination = "/tmp/os-setup.sh"
+  }
 
- # We run a remote provisioner on the instance after creating it.
+  # We run a remote provisioner on the instance after creating it.
   # In this case, we just install nginx and start it. By default,
   # this should be on port 80
-    provisioner "remote-exec" {
+  provisioner "remote-exec" {
     inline = [
       "sudo chmod +x /tmp/os-setup.sh",
       "sudo bash /tmp/os-setup.sh",
@@ -61,194 +60,205 @@ resource "aws_instance" "bootstrap" {
   }
 }
 
-
 # Create DCOS Mesos Master Scripts to execute
-  module "dcos-bootstrap" {
-    source = "github.com/dcos/tf_dcos_core"
-    bootstrap_private_ip = "${aws_instance.bootstrap.private_ip}"
-    # Only allow upgrade and install as installation mode
-    dcos_install_mode = "${var.state == "upgrade" ? "upgrade" : "install"}"
-    dcos_version = "${var.dcos_version}"
-    role = "dcos-bootstrap"
-    dcos_bootstrap_port = "${var.custom_dcos_bootstrap_port}"
-    custom_dcos_download_path = "${var.custom_dcos_download_path}"
-    # TODO(bernadinm) Terraform Bug: 9488.  Templates will not accept list, but only strings.
-    # Workaround is to flatten the list as a string below. Fix when this is closed.
-    dcos_public_agent_list = "\n - ${join("\n - ", aws_instance.public-agent.*.private_ip)}"
-    dcos_audit_logging = "${var.dcos_audit_logging}"
-    dcos_auth_cookie_secure_flag = "${var.dcos_auth_cookie_secure_flag}"
-    dcos_aws_access_key_id = "${var.dcos_aws_access_key_id}"
-    dcos_aws_region = "${coalesce(var.dcos_aws_region, var.aws_region)}"
-    dcos_aws_secret_access_key = "${var.dcos_aws_secret_access_key}"
-    dcos_aws_template_storage_access_key_id = "${var.dcos_aws_template_storage_access_key_id}"
-    dcos_aws_template_storage_bucket = "${var.dcos_aws_template_storage_bucket}"
-    dcos_aws_template_storage_bucket_path = "${var.dcos_aws_template_storage_bucket_path}"
-    dcos_aws_template_storage_region_name = "${var.dcos_aws_template_storage_region_name}"
-    dcos_aws_template_storage_secret_access_key = "${var.dcos_aws_template_storage_secret_access_key}"
-    dcos_aws_template_upload = "${var.dcos_aws_template_upload}"
-    dcos_bouncer_expiration_auth_token_days = "${var.dcos_bouncer_expiration_auth_token_days}"
-    dcos_check_time = "${var.dcos_check_time}"
-    dcos_cluster_docker_credentials = "${var.dcos_cluster_docker_credentials}"
-    dcos_cluster_docker_credentials_dcos_owned = "${var.dcos_cluster_docker_credentials_dcos_owned}"
-    dcos_cluster_docker_credentials_enabled = "${var.dcos_cluster_docker_credentials_enabled}"
-    dcos_cluster_docker_credentials_write_to_etc = "${var.dcos_cluster_docker_credentials_write_to_etc}"
-    dcos_cluster_name  = "${coalesce(var.dcos_cluster_name, data.template_file.cluster-name.rendered)}"
-    dcos_customer_key = "${var.dcos_customer_key}"
-    dcos_dns_search = "${var.dcos_dns_search}"
-    dcos_docker_remove_delay = "${var.dcos_docker_remove_delay}"
-    dcos_exhibitor_address = "${aws_elb.internal-master-elb.dns_name}"
-    dcos_exhibitor_azure_account_key = "${var.dcos_exhibitor_azure_account_key}"
-    dcos_exhibitor_azure_account_name = "${var.dcos_exhibitor_azure_account_name}"
-    dcos_exhibitor_azure_prefix = "${var.dcos_exhibitor_azure_prefix}"
-    dcos_exhibitor_explicit_keys = "${var.dcos_exhibitor_explicit_keys}"
-    dcos_exhibitor_storage_backend = "${var.dcos_exhibitor_storage_backend}"
-    dcos_exhibitor_zk_hosts = "${var.dcos_exhibitor_zk_hosts}"
-    dcos_exhibitor_zk_path = "${var.dcos_exhibitor_zk_path}"
-    dcos_license_key_contents= "${var.dcos_license_key_contents}"
-    dcos_gc_delay = "${var.dcos_gc_delay}"
-    dcos_http_proxy = "${var.dcos_http_proxy}"
-    dcos_https_proxy = "${var.dcos_https_proxy}"
-    dcos_log_directory = "${var.dcos_log_directory}"
-    dcos_master_external_loadbalancer = "${coalesce(var.dcos_master_external_loadbalancer, aws_elb.public-master-elb.dns_name)}"
-    dcos_master_discovery = "${var.dcos_master_discovery}"
-    dcos_master_dns_bindall = "${var.dcos_master_dns_bindall}"
-    # TODO(bernadinm) Terraform Bug: 9488.  Templates will not accept list, but only strings.
-    # Workaround is to flatten the list as a string below. Fix when this is closed.
-    dcos_master_list = "\n - ${join("\n - ", aws_instance.master.*.private_ip)}"
-    dcos_no_proxy = "${var.dcos_no_proxy}"
-    dcos_num_masters = "${var.num_of_masters}"
-    dcos_oauth_enabled = "${var.dcos_oauth_enabled}"
-    dcos_overlay_config_attempts = "${var.dcos_overlay_config_attempts}"
-    dcos_overlay_enable = "${var.dcos_overlay_enable}"
-    dcos_overlay_mtu = "${var.dcos_overlay_mtu}"
-    dcos_overlay_network = "${var.dcos_overlay_network}"
-    dcos_process_timeout = "${var.dcos_process_timeout}"
-    dcos_previous_version = "${var.dcos_previous_version}"
-    dcos_agent_list = "\n - ${join("\n - ", aws_instance.agent.*.private_ip)}"
-    # TODO(bernadinm) Terraform Bug: 9488.  Templates will not accept list, but only strings.
-    # Workaround is to flatten the list as a string below. Fix when this is closed.
-    dcos_resolvers  = "\n - ${join("\n - ", var.dcos_resolvers)}"
-    dcos_rexray_config_filename = "${var.dcos_rexray_config_filename}"
-    dcos_rexray_config_method = "${var.dcos_rexray_config_method}"
-    dcos_s3_bucket = "${coalesce(var.dcos_s3_bucket, aws_s3_bucket.dcos_bucket.id)}"
-    dcos_s3_prefix = "${coalesce(var.dcos_s3_prefix, aws_s3_bucket.dcos_bucket.id)}"
-    dcos_security  = "${var.dcos_security}"
-    dcos_superuser_password_hash = "${var.dcos_superuser_password_hash}"
-    dcos_superuser_username = "${var.dcos_superuser_username}"
-    dcos_telemetry_enabled = "${var.dcos_telemetry_enabled}"
-    dcos_use_proxy = "${var.dcos_use_proxy}"
-    dcos_zk_agent_credentials = "${var.dcos_zk_agent_credentials}"
-    dcos_zk_master_credentials = "${var.dcos_zk_master_credentials}"
-    dcos_zk_super_credentials = "${var.dcos_zk_super_credentials}"
-    dcos_cluster_docker_registry_url = "${var.dcos_cluster_docker_registry_url}"
-    dcos_rexray_config = "${var.dcos_rexray_config}"
-    dcos_ip_detect_public_contents = "${var.dcos_ip_detect_public_contents}"
-    dcos_enable_docker_gc = "${var.dcos_enable_docker_gc}"
-    dcos_staged_package_storage_uri = "${var.dcos_staged_package_storage_uri}"
-    dcos_package_storage_uri = "${var.dcos_package_storage_uri}"
- }
+module "dcos-bootstrap" {
+  source               = "github.com/dcos/tf_dcos_core"
+  bootstrap_private_ip = "${aws_instance.bootstrap.private_ip}"
+
+  # Only allow upgrade and install as installation mode
+  dcos_install_mode         = "${var.state == "upgrade" ? "upgrade" : "install"}"
+  dcos_version              = "${var.dcos_version}"
+  role                      = "dcos-bootstrap"
+  dcos_bootstrap_port       = "${var.custom_dcos_bootstrap_port}"
+  custom_dcos_download_path = "${var.custom_dcos_download_path}"
+
+  # TODO(bernadinm) Terraform Bug: 9488.  Templates will not accept list, but only strings.
+  # Workaround is to flatten the list as a string below. Fix when this is closed.
+  dcos_public_agent_list = "\n - ${join("\n - ", aws_instance.public-agent.*.private_ip)}"
+
+  dcos_audit_logging                           = "${var.dcos_audit_logging}"
+  dcos_auth_cookie_secure_flag                 = "${var.dcos_auth_cookie_secure_flag}"
+  dcos_aws_access_key_id                       = "${var.dcos_aws_access_key_id}"
+  dcos_aws_region                              = "${coalesce(var.dcos_aws_region, var.aws_region)}"
+  dcos_aws_secret_access_key                   = "${var.dcos_aws_secret_access_key}"
+  dcos_aws_template_storage_access_key_id      = "${var.dcos_aws_template_storage_access_key_id}"
+  dcos_aws_template_storage_bucket             = "${var.dcos_aws_template_storage_bucket}"
+  dcos_aws_template_storage_bucket_path        = "${var.dcos_aws_template_storage_bucket_path}"
+  dcos_aws_template_storage_region_name        = "${var.dcos_aws_template_storage_region_name}"
+  dcos_aws_template_storage_secret_access_key  = "${var.dcos_aws_template_storage_secret_access_key}"
+  dcos_aws_template_upload                     = "${var.dcos_aws_template_upload}"
+  dcos_bouncer_expiration_auth_token_days      = "${var.dcos_bouncer_expiration_auth_token_days}"
+  dcos_check_time                              = "${var.dcos_check_time}"
+  dcos_cluster_docker_credentials              = "${var.dcos_cluster_docker_credentials}"
+  dcos_cluster_docker_credentials_dcos_owned   = "${var.dcos_cluster_docker_credentials_dcos_owned}"
+  dcos_cluster_docker_credentials_enabled      = "${var.dcos_cluster_docker_credentials_enabled}"
+  dcos_cluster_docker_credentials_write_to_etc = "${var.dcos_cluster_docker_credentials_write_to_etc}"
+  dcos_cluster_name                            = "${coalesce(var.dcos_cluster_name, data.template_file.cluster-name.rendered)}"
+  dcos_customer_key                            = "${var.dcos_customer_key}"
+  dcos_dns_search                              = "${var.dcos_dns_search}"
+  dcos_docker_remove_delay                     = "${var.dcos_docker_remove_delay}"
+  dcos_exhibitor_address                       = "${aws_elb.internal-master-elb.dns_name}"
+  dcos_exhibitor_azure_account_key             = "${var.dcos_exhibitor_azure_account_key}"
+  dcos_exhibitor_azure_account_name            = "${var.dcos_exhibitor_azure_account_name}"
+  dcos_exhibitor_azure_prefix                  = "${var.dcos_exhibitor_azure_prefix}"
+  dcos_exhibitor_explicit_keys                 = "${var.dcos_exhibitor_explicit_keys}"
+  dcos_exhibitor_storage_backend               = "${var.dcos_exhibitor_storage_backend}"
+  dcos_exhibitor_zk_hosts                      = "${var.dcos_exhibitor_zk_hosts}"
+  dcos_exhibitor_zk_path                       = "${var.dcos_exhibitor_zk_path}"
+  dcos_license_key_contents                    = "${var.dcos_license_key_contents}"
+  dcos_gc_delay                                = "${var.dcos_gc_delay}"
+  dcos_http_proxy                              = "${var.dcos_http_proxy}"
+  dcos_https_proxy                             = "${var.dcos_https_proxy}"
+  dcos_log_directory                           = "${var.dcos_log_directory}"
+  dcos_master_external_loadbalancer            = "${coalesce(var.dcos_master_external_loadbalancer, aws_elb.public-master-elb.dns_name)}"
+  dcos_master_discovery                        = "${var.dcos_master_discovery}"
+  dcos_master_dns_bindall                      = "${var.dcos_master_dns_bindall}"
+
+  # TODO(bernadinm) Terraform Bug: 9488.  Templates will not accept list, but only strings.
+  # Workaround is to flatten the list as a string below. Fix when this is closed.
+  dcos_master_list = "\n - ${join("\n - ", aws_instance.master.*.private_ip)}"
+
+  dcos_no_proxy                = "${var.dcos_no_proxy}"
+  dcos_num_masters             = "${var.num_of_masters}"
+  dcos_oauth_enabled           = "${var.dcos_oauth_enabled}"
+  dcos_overlay_config_attempts = "${var.dcos_overlay_config_attempts}"
+  dcos_overlay_enable          = "${var.dcos_overlay_enable}"
+  dcos_overlay_mtu             = "${var.dcos_overlay_mtu}"
+  dcos_overlay_network         = "${var.dcos_overlay_network}"
+  dcos_process_timeout         = "${var.dcos_process_timeout}"
+  dcos_previous_version        = "${var.dcos_previous_version}"
+  dcos_agent_list              = "\n - ${join("\n - ", aws_instance.agent.*.private_ip)}"
+
+  # TODO(bernadinm) Terraform Bug: 9488.  Templates will not accept list, but only strings.
+  # Workaround is to flatten the list as a string below. Fix when this is closed.
+  dcos_resolvers = "\n - ${join("\n - ", var.dcos_resolvers)}"
+
+  dcos_rexray_config_filename      = "${var.dcos_rexray_config_filename}"
+  dcos_rexray_config_method        = "${var.dcos_rexray_config_method}"
+  dcos_s3_bucket                   = "${coalesce(var.dcos_s3_bucket, aws_s3_bucket.dcos_bucket.id)}"
+  dcos_s3_prefix                   = "${coalesce(var.dcos_s3_prefix, aws_s3_bucket.dcos_bucket.id)}"
+  dcos_security                    = "${var.dcos_security}"
+  dcos_superuser_password_hash     = "${local.dcos_superuser_password_hash}"
+  dcos_superuser_username          = "${var.dcos_superuser_username}"
+  dcos_telemetry_enabled           = "${var.dcos_telemetry_enabled}"
+  dcos_use_proxy                   = "${var.dcos_use_proxy}"
+  dcos_zk_agent_credentials        = "${var.dcos_zk_agent_credentials}"
+  dcos_zk_master_credentials       = "${var.dcos_zk_master_credentials}"
+  dcos_zk_super_credentials        = "${var.dcos_zk_super_credentials}"
+  dcos_cluster_docker_registry_url = "${var.dcos_cluster_docker_registry_url}"
+  dcos_rexray_config               = "${var.dcos_rexray_config}"
+  dcos_ip_detect_public_contents   = "${var.dcos_ip_detect_public_contents}"
+  dcos_enable_docker_gc            = "${var.dcos_enable_docker_gc}"
+  dcos_staged_package_storage_uri  = "${var.dcos_staged_package_storage_uri}"
+  dcos_package_storage_uri         = "${var.dcos_package_storage_uri}"
+}
 
 resource "null_resource" "bootstrap" {
   # If state is set to none do not install DC/OS
   count = "${var.state == "none" ? 0 : 1}"
+
   # Changes to any instance of the cluster requires re-provisioning
   triggers {
-    cluster_instance_ids = "${aws_instance.bootstrap.id}"
-    dcos_version = "${var.dcos_version}"
-    dcos_security = "${var.dcos_security}"
-    num_of_masters = "${var.num_of_masters}"
-    dcos_bootstrap_port = "${var.custom_dcos_bootstrap_port}"
-    dcos_audit_logging = "${var.dcos_audit_logging}"
-    dcos_auth_cookie_secure_flag = "${var.dcos_auth_cookie_secure_flag}"
-    dcos_aws_access_key_id = "${var.dcos_aws_access_key_id}"
-    dcos_aws_region = "${coalesce(var.dcos_aws_region, var.aws_region)}"
-    dcos_aws_secret_access_key = "${var.dcos_aws_secret_access_key}"
-    dcos_aws_template_storage_access_key_id = "${var.dcos_aws_template_storage_access_key_id}"
-    dcos_aws_template_storage_bucket = "${var.dcos_aws_template_storage_bucket}"
-    dcos_aws_template_storage_bucket_path = "${var.dcos_aws_template_storage_bucket_path}"
-    dcos_aws_template_storage_region_name = "${var.dcos_aws_template_storage_region_name}"
-    dcos_aws_template_storage_secret_access_key = "${var.dcos_aws_template_storage_secret_access_key}"
-    dcos_aws_template_upload = "${var.dcos_aws_template_upload}"
-    dcos_bouncer_expiration_auth_token_days = "${var.dcos_bouncer_expiration_auth_token_days}"
-    dcos_check_time = "${var.dcos_check_time}"
-    dcos_cluster_docker_credentials = "${var.dcos_cluster_docker_credentials}"
-    dcos_cluster_docker_credentials_dcos_owned = "${var.dcos_cluster_docker_credentials_dcos_owned}"
-    dcos_cluster_docker_credentials_enabled = "${var.dcos_cluster_docker_credentials_enabled}"
+    cluster_instance_ids                         = "${aws_instance.bootstrap.id}"
+    dcos_version                                 = "${var.dcos_version}"
+    dcos_security                                = "${var.dcos_security}"
+    num_of_masters                               = "${var.num_of_masters}"
+    dcos_bootstrap_port                          = "${var.custom_dcos_bootstrap_port}"
+    dcos_audit_logging                           = "${var.dcos_audit_logging}"
+    dcos_auth_cookie_secure_flag                 = "${var.dcos_auth_cookie_secure_flag}"
+    dcos_aws_access_key_id                       = "${var.dcos_aws_access_key_id}"
+    dcos_aws_region                              = "${coalesce(var.dcos_aws_region, var.aws_region)}"
+    dcos_aws_secret_access_key                   = "${var.dcos_aws_secret_access_key}"
+    dcos_aws_template_storage_access_key_id      = "${var.dcos_aws_template_storage_access_key_id}"
+    dcos_aws_template_storage_bucket             = "${var.dcos_aws_template_storage_bucket}"
+    dcos_aws_template_storage_bucket_path        = "${var.dcos_aws_template_storage_bucket_path}"
+    dcos_aws_template_storage_region_name        = "${var.dcos_aws_template_storage_region_name}"
+    dcos_aws_template_storage_secret_access_key  = "${var.dcos_aws_template_storage_secret_access_key}"
+    dcos_aws_template_upload                     = "${var.dcos_aws_template_upload}"
+    dcos_bouncer_expiration_auth_token_days      = "${var.dcos_bouncer_expiration_auth_token_days}"
+    dcos_check_time                              = "${var.dcos_check_time}"
+    dcos_cluster_docker_credentials              = "${var.dcos_cluster_docker_credentials}"
+    dcos_cluster_docker_credentials_dcos_owned   = "${var.dcos_cluster_docker_credentials_dcos_owned}"
+    dcos_cluster_docker_credentials_enabled      = "${var.dcos_cluster_docker_credentials_enabled}"
     dcos_cluster_docker_credentials_write_to_etc = "${var.dcos_cluster_docker_credentials_write_to_etc}"
-    dcos_cluster_name  = "${coalesce(var.dcos_cluster_name, data.template_file.cluster-name.rendered)}"
-    dcos_customer_key = "${var.dcos_customer_key}"
-    dcos_dns_search = "${var.dcos_dns_search}"
-    dcos_docker_remove_delay = "${var.dcos_docker_remove_delay}"
-    dcos_exhibitor_address = "${aws_elb.internal-master-elb.dns_name}"
-    dcos_exhibitor_azure_account_key = "${var.dcos_exhibitor_azure_account_key}"
-    dcos_exhibitor_azure_account_name = "${var.dcos_exhibitor_azure_account_name}"
-    dcos_exhibitor_azure_prefix = "${var.dcos_exhibitor_azure_prefix}"
-    dcos_exhibitor_explicit_keys = "${var.dcos_exhibitor_explicit_keys}"
-    dcos_exhibitor_storage_backend = "${var.dcos_exhibitor_storage_backend}"
-    dcos_exhibitor_zk_hosts = "${var.dcos_exhibitor_zk_hosts}"
-    dcos_exhibitor_zk_path = "${var.dcos_exhibitor_zk_path}"
-    dcos_license_key_contents= "${var.dcos_license_key_contents}"
-    dcos_gc_delay = "${var.dcos_gc_delay}"
-    dcos_http_proxy = "${var.dcos_http_proxy}"
-    dcos_https_proxy = "${var.dcos_https_proxy}"
-    dcos_log_directory = "${var.dcos_log_directory}"
-    dcos_master_external_loadbalancer = "${coalesce(var.dcos_master_external_loadbalancer, aws_elb.public-master-elb.dns_name)}"
-    dcos_master_discovery = "${var.dcos_master_discovery}"
-    dcos_master_dns_bindall = "${var.dcos_master_dns_bindall}"
+    dcos_cluster_name                            = "${coalesce(var.dcos_cluster_name, data.template_file.cluster-name.rendered)}"
+    dcos_customer_key                            = "${var.dcos_customer_key}"
+    dcos_dns_search                              = "${var.dcos_dns_search}"
+    dcos_docker_remove_delay                     = "${var.dcos_docker_remove_delay}"
+    dcos_exhibitor_address                       = "${aws_elb.internal-master-elb.dns_name}"
+    dcos_exhibitor_azure_account_key             = "${var.dcos_exhibitor_azure_account_key}"
+    dcos_exhibitor_azure_account_name            = "${var.dcos_exhibitor_azure_account_name}"
+    dcos_exhibitor_azure_prefix                  = "${var.dcos_exhibitor_azure_prefix}"
+    dcos_exhibitor_explicit_keys                 = "${var.dcos_exhibitor_explicit_keys}"
+    dcos_exhibitor_storage_backend               = "${var.dcos_exhibitor_storage_backend}"
+    dcos_exhibitor_zk_hosts                      = "${var.dcos_exhibitor_zk_hosts}"
+    dcos_exhibitor_zk_path                       = "${var.dcos_exhibitor_zk_path}"
+    dcos_license_key_contents                    = "${var.dcos_license_key_contents}"
+    dcos_gc_delay                                = "${var.dcos_gc_delay}"
+    dcos_http_proxy                              = "${var.dcos_http_proxy}"
+    dcos_https_proxy                             = "${var.dcos_https_proxy}"
+    dcos_log_directory                           = "${var.dcos_log_directory}"
+    dcos_master_external_loadbalancer            = "${coalesce(var.dcos_master_external_loadbalancer, aws_elb.public-master-elb.dns_name)}"
+    dcos_master_discovery                        = "${var.dcos_master_discovery}"
+    dcos_master_dns_bindall                      = "${var.dcos_master_dns_bindall}"
+
     # TODO(bernadinm) Terraform Bug: 9488.  Templates will not accept list, but only strings.
     # Workaround is to flatten the list as a string below. Fix when this is closed.
     dcos_no_proxy = "${var.dcos_no_proxy}"
-    dcos_num_masters = "${var.num_of_masters}"
-    dcos_oauth_enabled = "${var.dcos_oauth_enabled}"
+
+    dcos_num_masters             = "${var.num_of_masters}"
+    dcos_oauth_enabled           = "${var.dcos_oauth_enabled}"
     dcos_overlay_config_attempts = "${var.dcos_overlay_config_attempts}"
-    dcos_overlay_enable = "${var.dcos_overlay_enable}"
-    dcos_overlay_mtu = "${var.dcos_overlay_mtu}"
-    dcos_overlay_network = "${var.dcos_overlay_network}"
-    dcos_process_timeout = "${var.dcos_process_timeout}"
-    dcos_previous_version = "${var.dcos_previous_version}"
+    dcos_overlay_enable          = "${var.dcos_overlay_enable}"
+    dcos_overlay_mtu             = "${var.dcos_overlay_mtu}"
+    dcos_overlay_network         = "${var.dcos_overlay_network}"
+    dcos_process_timeout         = "${var.dcos_process_timeout}"
+    dcos_previous_version        = "${var.dcos_previous_version}"
+
     # TODO(bernadinm) Terraform Bug: 9488.  Templates will not accept list, but only strings.
     # Workaround is to flatten the list as a string below. Fix when this is closed.
-    dcos_resolvers  = "\n - ${join("\n - ", var.dcos_resolvers)}"
-    dcos_rexray_config_filename = "${var.dcos_rexray_config_filename}"
-    dcos_rexray_config_method = "${var.dcos_rexray_config_method}"
-    dcos_s3_bucket = "${coalesce(var.dcos_s3_bucket, aws_s3_bucket.dcos_bucket.id)}"
-    dcos_s3_prefix = "${coalesce(var.dcos_s3_prefix, aws_s3_bucket.dcos_bucket.id)}"
-    dcos_security  = "${var.dcos_security}"
-    dcos_superuser_password_hash = "${var.dcos_superuser_password_hash}"
-    dcos_superuser_username = "${var.dcos_superuser_username}"
-    dcos_telemetry_enabled = "${var.dcos_telemetry_enabled}"
-    dcos_use_proxy = "${var.dcos_use_proxy}"
-    dcos_zk_agent_credentials = "${var.dcos_zk_agent_credentials}"
-    dcos_zk_master_credentials = "${var.dcos_zk_master_credentials}"
-    dcos_zk_super_credentials = "${var.dcos_zk_super_credentials}"
+    dcos_resolvers = "\n - ${join("\n - ", var.dcos_resolvers)}"
+
+    dcos_rexray_config_filename      = "${var.dcos_rexray_config_filename}"
+    dcos_rexray_config_method        = "${var.dcos_rexray_config_method}"
+    dcos_s3_bucket                   = "${coalesce(var.dcos_s3_bucket, aws_s3_bucket.dcos_bucket.id)}"
+    dcos_s3_prefix                   = "${coalesce(var.dcos_s3_prefix, aws_s3_bucket.dcos_bucket.id)}"
+    dcos_security                    = "${var.dcos_security}"
+    dcos_superuser_password_hash     = "${local.dcos_superuser_password_hash}"
+    dcos_superuser_username          = "${var.dcos_superuser_username}"
+    dcos_telemetry_enabled           = "${var.dcos_telemetry_enabled}"
+    dcos_use_proxy                   = "${var.dcos_use_proxy}"
+    dcos_zk_agent_credentials        = "${var.dcos_zk_agent_credentials}"
+    dcos_zk_master_credentials       = "${var.dcos_zk_master_credentials}"
+    dcos_zk_super_credentials        = "${var.dcos_zk_super_credentials}"
     dcos_cluster_docker_registry_url = "${var.dcos_cluster_docker_registry_url}"
-    dcos_rexray_config = "${var.dcos_rexray_config}"
-    dcos_ip_detect_public_contents = "${var.dcos_ip_detect_public_contents}"
-    dcos_enable_docker_gc = "${var.dcos_enable_docker_gc}"
-    dcos_staged_package_storage_uri = "${var.dcos_staged_package_storage_uri}"
-    dcos_package_storage_uri = "${var.dcos_package_storage_uri}"
+    dcos_rexray_config               = "${var.dcos_rexray_config}"
+    dcos_ip_detect_public_contents   = "${var.dcos_ip_detect_public_contents}"
+    dcos_enable_docker_gc            = "${var.dcos_enable_docker_gc}"
+    dcos_staged_package_storage_uri  = "${var.dcos_staged_package_storage_uri}"
+    dcos_package_storage_uri         = "${var.dcos_package_storage_uri}"
   }
 
   # Bootstrap script can run on any instance of the cluster
   # So we just choose the first in this case
   connection {
-    host = "${element(aws_instance.bootstrap.*.public_ip, 0)}"
-    user = "${module.aws-tested-oses.user}"
+    host        = "${element(aws_instance.bootstrap.*.public_ip, 0)}"
+    user        = "${module.aws-tested-oses.user}"
     private_key = "${local.private_key}"
-    agent = "${local.agent}"
+    agent       = "${local.agent}"
   }
 
   # DCOS ip detect script
   provisioner "file" {
-   source = "${var.ip-detect["aws"]}"
-   destination = "/tmp/ip-detect"
-   }
+    source      = "${var.ip-detect["aws"]}"
+    destination = "/tmp/ip-detect"
+  }
 
   # DCOS fault domain detect script
   provisioner "file" {
-   source = "${var.dcos_fault_domain_detect_filename}"
-   destination = "/tmp/fault-domain-detect"
-   }
+    source      = "${var.dcos_fault_domain_detect_filename}"
+    destination = "/tmp/fault-domain-detect"
+  }
 
   # Generate and upload bootstrap script to node
   provisioner "file" {

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -303,11 +303,6 @@ variable "dcos_superuser_password" {
   description = "This required parameter specifies the plaintext superuser password (EE only). NOTE: THIS MUST NOT BE STORED ANYWHERE, NOR USED FOR ANYTHING OTHER THAN GENERATING dcos_superuser_password_hash. USE AN ENVIRONMENT VARIABLE."
 }
 
-variable "dcos_superuser_password_hash" {
-  default     = "${sha512("${dcos_superuser_password}")}"
-  description = "This required parameter specifies the hashed superuser password. (EE only)"
-}
-
 variable "dcos_cluster_name" {
   default     = ""
   description = "Name of the DC/OS Cluster"

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -1,18 +1,19 @@
 variable "ssh_key_name" {
   description = "ssh key name associated with your instances for login"
-  default = "default"
+  default     = "default"
 }
 
 variable "ssh_private_key_filename" {
- # cannot leave this empty as the file() interpolation will fail later on for the private_key local variable
- # https://github.com/hashicorp/terraform/issues/15605
- default = "/dev/null"
- description = "Path to file containing your ssh private key"
+  # cannot leave this empty as the file() interpolation will fail later on for the private_key local variable
+  # https://github.com/hashicorp/terraform/issues/15605
+  default = "/dev/null"
+
+  description = "Path to file containing your ssh private key"
 }
 
 variable "user" {
   description = "Username of the OS"
-  default = "core"
+  default     = "core"
 }
 
 variable "aws_region" {
@@ -31,465 +32,468 @@ variable "admin_cidr" {
 }
 
 variable "os" {
-  default = "coreos_1235.9.0"
+  default     = "coreos_1235.9.0"
   description = "Recommended DC/OS OSs are centos_7.2, coreos_1235.9.0, coreos_835.13.0"
 }
 
 variable "aws_master_instance_type" {
   description = "AWS DC/OS master instance type"
-  default = "m3.xlarge"
+  default     = "m3.xlarge"
 }
 
 variable "aws_master_instance_disk_size" {
   description = "AWS DC/OS Master instance type default size of the root disk (GB)"
-  default = "60"
+  default     = "60"
 }
 
 variable "aws_agent_instance_type" {
   description = "AWS DC/OS Private Agent instance type"
-  default = "m3.xlarge"
+  default     = "m3.xlarge"
 }
 
 variable "aws_agent_instance_disk_size" {
   description = "AWS DC/OS Private Agent instance type default size of the root disk (GB)"
-  default = "60"
+  default     = "60"
 }
 
 variable "aws_public_agent_instance_type" {
   description = "AWS DC/OS Public instance type"
-  default = "m3.xlarge"
+  default     = "m3.xlarge"
 }
 
 variable "aws_public_agent_instance_disk_size" {
   description = "AWS DC/OS Public instance type default size of the root disk (GB)"
-  default = "60"
+  default     = "60"
 }
 
 variable "aws_bootstrap_instance_type" {
   description = "AWS DC/OS Bootstrap instance type"
-  default = "m3.large"
+  default     = "m3.large"
 }
 
 variable "aws_bootstrap_instance_disk_size" {
   description = "AWS DC/OS bootstrap instance type default size of the root disk (GB)"
-  default = "60"
+  default     = "60"
 }
 
 variable "num_of_private_agents" {
   description = "DC/OS Private Agents Count"
-  default = 2
+  default     = 2
 }
 
 variable "num_of_public_agents" {
   description = "DC/OS Public Agents Count"
-  default = 1
+  default     = 1
 }
 
 variable "num_of_masters" {
   description = "DC/OS Master Nodes Count (Odd only)"
-  default = 3
+  default     = 3
 }
 
 variable "owner" {
   description = "Paired with Cloud Cluster Cleaner will notify on expiration via slack. Default is whoami. Can be overwritten by setting the value here"
-  default = ""
+  default     = ""
 }
 
 variable "expiration" {
   description = "Paired with Cloud Cluster Cleaner will notify on expiration via slack"
-  default = "1h"
+  default     = "1h"
 }
 
 variable "ip-detect" {
- description = "Used to determine the private IP address of instances"
- type = "map"
+  description = "Used to determine the private IP address of instances"
+  type        = "map"
 
- default = {
-  aws = "scripts/cloud/aws/ip-detect.aws.sh"
- }
+  default = {
+    aws = "scripts/cloud/aws/ip-detect.aws.sh"
+  }
 }
 
 variable "dcos_fault_domain_detect_filename" {
- default = "scripts/cloud/aws/fault-domain-detect"
+  default = "scripts/cloud/aws/fault-domain-detect"
 }
 
 variable "os-init-script" {
- description = "Init Scripts that runs post-AMI deployment and pre-DC/OS install"
- type = "map"
+  description = "Init Scripts that runs post-AMI deployment and pre-DC/OS install"
+  type        = "map"
 
- default = {
-  coreos = "scripts/os/coreos/coreos-init.aws.sh"
-  centos = "scripts/os/centos/centos-init.aws.sh"
- }
+  default = {
+    coreos = "scripts/os/coreos/coreos-init.aws.sh"
+    centos = "scripts/os/centos/centos-init.aws.sh"
+  }
 }
 
 variable "instance_disk_size" {
- description = "Default size of the root disk (GB)"
- default = "128"
+  description = "Default size of the root disk (GB)"
+  default     = "128"
 }
 
 variable "custom_dcos_bootstrap_port" {
- default = "80"
- description = "Nginx Port for serving bootstrap files"
+  default     = "80"
+  description = "Nginx Port for serving bootstrap files"
 }
 
 variable "custom_dcos_download_path" {
- default = ""
- description = "Custom DC/OS version path"
+  default     = ""
+  description = "Custom DC/OS version path"
 }
 
 variable "dcos_security" {
- default = ""
- description = "DC/OS EE security mode: either disabled, permissive, or strict."
+  default     = ""
+  description = "DC/OS EE security mode: either disabled, permissive, or strict."
 }
 
 variable "dcos_resolvers" {
- default = [ "169.254.169.253" ]
- description = "DNS Resolver for internal name resolution. Points to Amazon DNS server which can resolve external addresses."
+  default     = ["169.254.169.253"]
+  description = "DNS Resolver for internal name resolution. Points to Amazon DNS server which can resolve external addresses."
 }
 
 variable "dcos_oauth_enabled" {
- default = ""
- description = "DC/OS Open Flag for Open Auth"
+  default     = ""
+  description = "DC/OS Open Flag for Open Auth"
 }
 
 variable "dcos_master_external_loadbalancer" {
- default = ""
- description = "Used to allow DC/OS to set any required certs. Used for DC/OS EE."
+  default     = ""
+  description = "Used to allow DC/OS to set any required certs. Used for DC/OS EE."
 }
 
 variable "dcos_master_discovery" {
- default = "master_http_loadbalancer"
- description = "Ability to use an ELB or a static list for master descovery"
+  default     = "master_http_loadbalancer"
+  description = "Ability to use an ELB or a static list for master descovery"
 }
 
 variable "dcos_aws_template_storage_bucket" {
- default = ""
- description = "This parameter specifies the name of your S3 bucket"
+  default     = ""
+  description = "This parameter specifies the name of your S3 bucket"
 }
 
 variable "dcos_aws_template_storage_bucket_path" {
- default = ""
- description = "This parameter specifies the S3 bucket storage path"
+  default     = ""
+  description = "This parameter specifies the S3 bucket storage path"
 }
 
 variable "dcos_aws_template_storage_region_name" {
- default = ""
- description = "This parameter specifies the S3 region"
+  default     = ""
+  description = "This parameter specifies the S3 region"
 }
 
 variable "dcos_aws_template_upload" {
- default = ""
- description = "This parameter specifies whether to automatically upload the customized advanced templates to your S3 bucket"
+  default     = ""
+  description = "This parameter specifies whether to automatically upload the customized advanced templates to your S3 bucket"
 }
 
 variable "dcos_aws_template_storage_access_key_id" {
- default = ""
- description = "This parameters specifies the AWS Access Key ID"
+  default     = ""
+  description = "This parameters specifies the AWS Access Key ID"
 }
 
 variable "dcos_aws_template_storage_secret_access_key" {
- default = ""
- description = "This parameter specifies the AWS Secret Access Key"
+  default     = ""
+  description = "This parameter specifies the AWS Secret Access Key"
 }
 
 variable "dcos_exhibitor_storage_backend" {
- default = "aws_s3"
- description = "specify an external storage system (static, zookeeper, azure, and aws_s3)"
+  default     = "aws_s3"
+  description = "specify an external storage system (static, zookeeper, azure, and aws_s3)"
 }
 
 variable "dcos_exhibitor_zk_hosts" {
- default = ""
- description = "This parameter specifies a comma-separated list (<ZK_IP>:<ZK_PORT>, <ZK_IP>:<ZK_PORT>, <ZK_IP:ZK_PORT>) of one or more ZooKeeper node IP and port addresses to use for configuring the internal Exhibitor instances"
+  default     = ""
+  description = "This parameter specifies a comma-separated list (<ZK_IP>:<ZK_PORT>, <ZK_IP>:<ZK_PORT>, <ZK_IP:ZK_PORT>) of one or more ZooKeeper node IP and port addresses to use for configuring the internal Exhibitor instances"
 }
 
 variable "dcos_exhibitor_zk_path" {
- default = ""
- description = "This parameter specifies the filepath that Exhibitor uses to store data"
+  default     = ""
+  description = "This parameter specifies the filepath that Exhibitor uses to store data"
 }
 
 variable "dcos_aws_access_key_id" {
- default = ""
- description = "This parameter specifies AWS key ID"
+  default     = ""
+  description = "This parameter specifies AWS key ID"
 }
 
 variable "dcos_aws_region" {
- default = ""
- description = "This parameter specifies AWS region for your S3 bucket."
+  default     = ""
+  description = "This parameter specifies AWS region for your S3 bucket."
 }
 
 variable "dcos_aws_secret_access_key" {
- default = ""
- description = "This parameter specifies AWS secret access key"
+  default     = ""
+  description = "This parameter specifies AWS secret access key"
 }
 
 variable "dcos_exhibitor_explicit_keys" {
- default = "false"
- description = "This parameter specifies whether you are using AWS API keys to grant Exhibitor access to S3."
+  default     = "false"
+  description = "This parameter specifies whether you are using AWS API keys to grant Exhibitor access to S3."
 }
 
 variable "dcos_s3_bucket" {
- default = ""
- description = "This parameter specifies name of your S3 bucket."
+  default     = ""
+  description = "This parameter specifies name of your S3 bucket."
 }
 
 variable "dcos_s3_prefix" {
- default = ""
- description = "This parameter specifies S3 prefix to be used within your S3 bucket to be used by Exhibitor."
+  default     = ""
+  description = "This parameter specifies S3 prefix to be used within your S3 bucket to be used by Exhibitor."
 }
 
 variable "dcos_exhibitor_azure_account_name" {
- default = ""
- description = "This parameter specifies the Azure Storage Account Name. If you specify azure for exhibitor backed set this value."
+  default     = ""
+  description = "This parameter specifies the Azure Storage Account Name. If you specify azure for exhibitor backed set this value."
 }
 
 variable "dcos_exhibitor_azure_account_key" {
- default = ""
- description = "This parameter specifies a secret key to access the Azure Storage Account. If you specify azure for exhibitor backed set this value."
+  default     = ""
+  description = "This parameter specifies a secret key to access the Azure Storage Account. If you specify azure for exhibitor backed set this value."
 }
 
 variable "dcos_exhibitor_azure_prefix" {
- default = ""
- description = "This parameter specifies the blob prefix to be used within your Storage Account to be used by Exhibitor. If you specify azure for exhibitor backed set this value."
+  default     = ""
+  description = "This parameter specifies the blob prefix to be used within your Storage Account to be used by Exhibitor. If you specify azure for exhibitor backed set this value."
 }
 
 variable "dcos_exhibitor_address" {
- default = ""
- description = "This required parameter specifies the location (preferably an IP address) of the load balancer in front of the masters."
+  default     = ""
+  description = "This required parameter specifies the location (preferably an IP address) of the load balancer in front of the masters."
 }
 
 variable "dcos_num_masters" {
- default = ""
- description = "This parameter specifies the number of Mesos masters in your DC/OS cluster. If master_discovery: static, do not use the num_masters parameter"
+  default     = ""
+  description = "This parameter specifies the number of Mesos masters in your DC/OS cluster. If master_discovery: static, do not use the num_masters parameter"
 }
 
 variable "dcos_customer_key" {
- default = ""
- description = "This parameter specifies the Enterprise DC/OS customer key."
+  default     = ""
+  description = "This parameter specifies the Enterprise DC/OS customer key."
 }
 
 variable "dcos_rexray_config_method" {
- default = ""
- description = "This parameter specifies the REX-Ray configuration method for enabling external persistent volumes in Marathon. "
+  default     = ""
+  description = "This parameter specifies the REX-Ray configuration method for enabling external persistent volumes in Marathon. "
 }
 
 variable "dcos_rexray_config_filename" {
- default = ""
- description = "Specify the path to a REX-Ray configuration file with rexray_config_filename"
+  default     = ""
+  description = "Specify the path to a REX-Ray configuration file with rexray_config_filename"
 }
 
 variable "dcos_auth_cookie_secure_flag" {
- default = ""
- description = "This parameter specifies whether to allow web browsers to send the DC/OS authentication cookie through a non-HTTPS connection. Because the DC/OS authentication cookie allows access to the DC/OS cluster, it should be sent over an encrypted connection to prevent man-in-the-middle attacks."
+  default     = ""
+  description = "This parameter specifies whether to allow web browsers to send the DC/OS authentication cookie through a non-HTTPS connection. Because the DC/OS authentication cookie allows access to the DC/OS cluster, it should be sent over an encrypted connection to prevent man-in-the-middle attacks."
 }
 
 variable "dcos_bouncer_expiration_auth_token_days" {
- default = ""
- description = "This parameter sets the auth token time-to-live (TTL) for Identity and Access Management."
+  default     = ""
+  description = "This parameter sets the auth token time-to-live (TTL) for Identity and Access Management."
 }
 
 variable "ssh_port" {
- default = "22"
- description = "This parameter specifies the port to SSH to"
-}
-
-variable "dcos_superuser_password_hash" {
- default = ""
- description = "This required parameter specifies the hashed superuser password. (EE only)"
-}
-
-variable "dcos_cluster_name" {
- default = ""
- description = "Name of the DC/OS Cluster"
-}
-
-variable "dcos_license_key_contents" {
- default = ""
- description = "Used to privide the license key of DC/OS for Enterprise Edition"
+  default     = "22"
+  description = "This parameter specifies the port to SSH to"
 }
 
 variable "dcos_superuser_username" {
- default = ""
- description = "This required parameter specifies the Admin username. (EE only)"
+  default     = ""
+  description = "This required parameter specifies the Admin username. (EE only)"
+}
+
+variable "dcos_superuser_password" {
+  description = "This required parameter specifies the plaintext superuser password (EE only). NOTE: THIS MUST NOT BE STORED ANYWHERE, NOR USED FOR ANYTHING OTHER THAN GENERATING dcos_superuser_password_hash. USE AN ENVIRONMENT VARIABLE."
+}
+
+variable "dcos_superuser_password_hash" {
+  default     = "${sha512("${dcos_superuser_password}")}"
+  description = "This required parameter specifies the hashed superuser password. (EE only)"
+}
+
+variable "dcos_cluster_name" {
+  default     = ""
+  description = "Name of the DC/OS Cluster"
+}
+
+variable "dcos_license_key_contents" {
+  default     = ""
+  description = "Used to privide the license key of DC/OS for Enterprise Edition"
 }
 
 variable "dcos_telemetry_enabled" {
- default = ""
- description = "This parameter specifies whether to enable sharing of anonymous data for your cluster."
+  default     = ""
+  description = "This parameter specifies whether to enable sharing of anonymous data for your cluster."
 }
 
 variable "dcos_zk_super_credentials" {
- default = ""
- description = "This parameter specifies the ZooKeeper superuser credentials. (EE only)"
+  default     = ""
+  description = "This parameter specifies the ZooKeeper superuser credentials. (EE only)"
 }
 
 variable "dcos_zk_master_credentials" {
- default = ""
- description = "This parameter specifies the ZooKeeper master credentials."
+  default     = ""
+  description = "This parameter specifies the ZooKeeper master credentials."
 }
 
 variable "dcos_zk_agent_credentials" {
- default = ""
- description = "This parameter specifies the ZooKeeper agent credentials. "
+  default     = ""
+  description = "This parameter specifies the ZooKeeper agent credentials. "
 }
 
 variable "dcos_overlay_enable" {
- default = ""
- description = "Enable the DC/OS virtual network. "
+  default     = ""
+  description = "Enable the DC/OS virtual network. "
 }
 
 variable "dcos_overlay_config_attempts" {
- default = ""
- description = "This parameter specifies how many failed configuration attempts are allowed before the overlay configuration modules stop trying to configure an virtual network."
+  default     = ""
+  description = "This parameter specifies how many failed configuration attempts are allowed before the overlay configuration modules stop trying to configure an virtual network."
 }
 
 variable "dcos_overlay_mtu" {
- default = ""
- description = "This parameter specifies the maximum transmission unit (MTU) of the Virtual Ethernet (vEth) on the containers that are launched on the overlay."
+  default     = ""
+  description = "This parameter specifies the maximum transmission unit (MTU) of the Virtual Ethernet (vEth) on the containers that are launched on the overlay."
 }
 
 # Example how to set an overlay network below
 # default = "{\"vtep_mac_oui\": \"70:B3:D5:00:00:00\", \"overlays\": [{\"name\": \"dcos\", \"subnet\": \"9.0.0.0/8\", \"prefix\": 26}], \"vtep_subnet\": \"44.128.0.0/20\"}"
 
 variable "dcos_overlay_network" {
- default = ""
- description = "Specify this in line in a new line (\\n) fashion. See https://docs.mesosphere.com/1.8/administration/installing/custom/configuration-parameters/ for more information"
+  default     = ""
+  description = "Specify this in line in a new line (\\n) fashion. See https://docs.mesosphere.com/1.8/administration/installing/custom/configuration-parameters/ for more information"
 }
 
 variable "dcos_dns_search" {
- default = ""
- description = "This parameter specifies a space-separated list of domains that are tried when an unqualified domain is entered"
+  default     = ""
+  description = "This parameter specifies a space-separated list of domains that are tried when an unqualified domain is entered"
 }
 
 variable "dcos_master_dns_bindall" {
- default = ""
- description = "This parameter specifies whether the master DNS port is open. An open master DNS port listens publicly on the masters."
+  default     = ""
+  description = "This parameter specifies whether the master DNS port is open. An open master DNS port listens publicly on the masters."
 }
 
 variable "dcos_use_proxy" {
- default = ""
- description = "This parameter specifies whether to enable the DC/OS proxy."
+  default     = ""
+  description = "This parameter specifies whether to enable the DC/OS proxy."
 }
 
 variable "dcos_http_proxy" {
- default = ""
- description = "This parameter specifies the HTTP proxy."
+  default     = ""
+  description = "This parameter specifies the HTTP proxy."
 }
 
 variable "dcos_https_proxy" {
- default = ""
- description = "This parameter specifies the HTTPS proxy"
+  default     = ""
+  description = "This parameter specifies the HTTPS proxy"
 }
 
 variable "dcos_no_proxy" {
- default = ""
- description = "This parameter specifies YAML nested list (-) of addresses to exclude from the proxy."
+  default     = ""
+  description = "This parameter specifies YAML nested list (-) of addresses to exclude from the proxy."
 }
 
 variable "dcos_check_time" {
- default = ""
- description = "This parameter specifies whether to check if Network Time Protocol (NTP) is enabled during DC/OS startup. It recommended that NTP is enabled for a production environment."
+  default     = ""
+  description = "This parameter specifies whether to check if Network Time Protocol (NTP) is enabled during DC/OS startup. It recommended that NTP is enabled for a production environment."
 }
 
 variable "dcos_docker_remove_delay" {
- default = ""
- description = "This parameter specifies the amount of time to wait before removing stale Docker images stored on the agent nodes and the Docker image generated by the installer. "
+  default     = ""
+  description = "This parameter specifies the amount of time to wait before removing stale Docker images stored on the agent nodes and the Docker image generated by the installer. "
 }
 
 variable "dcos_audit_logging" {
- default = ""
- description = "This parameter specifies whether security decisions (authentication, authorization) are logged for Mesos, Marathon, and Jobs."
+  default     = ""
+  description = "This parameter specifies whether security decisions (authentication, authorization) are logged for Mesos, Marathon, and Jobs."
 }
 
 variable "dcos_gc_delay" {
- default = ""
- description = "This parameter specifies the maximum amount of time to wait before cleaning up the executor directories. It is recommended that you accept the default value of 2 days."
+  default     = ""
+  description = "This parameter specifies the maximum amount of time to wait before cleaning up the executor directories. It is recommended that you accept the default value of 2 days."
 }
 
 variable "dcos_log_directory" {
- default = ""
- description = "This parameter specifies the path to the installer host logs from the SSH processes. By default this is set to /genconf/logs."
+  default     = ""
+  description = "This parameter specifies the path to the installer host logs from the SSH processes. By default this is set to /genconf/logs."
 }
 
 variable "dcos_process_timeout" {
- default = ""
- description = "This parameter specifies the allowable amount of time, in seconds, for an action to begin after the process forks. This parameter is not the complete process time. The default value is 120 seconds."
+  default     = ""
+  description = "This parameter specifies the allowable amount of time, in seconds, for an action to begin after the process forks. This parameter is not the complete process time. The default value is 120 seconds."
 }
 
 variable "dcos_previous_version" {
- default = ""
- description = "Required by the DC/OS installer instructions to ensure the operator know what version they are upgrading from."
+  default     = ""
+  description = "Required by the DC/OS installer instructions to ensure the operator know what version they are upgrading from."
 }
 
 variable "dcos_version" {
- default = "1.11.1"
- description = "DCOS Version"
+  default     = "1.11.1"
+  description = "DCOS Version"
 }
 
 variable "dcos_cluster_docker_credentials" {
- default = ""
- description = "This parameter specifies a dictionary of Docker credentials to pass."
+  default     = ""
+  description = "This parameter specifies a dictionary of Docker credentials to pass."
 }
 
 variable "dcos_cluster_docker_credentials_dcos_owned" {
- default = ""
- description = "This parameter specifies whether to store the credentials file in /opt/mesosphere or /etc/mesosphere/docker_credentials. A sysadmin cannot edit /opt/mesosphere directly."
+  default     = ""
+  description = "This parameter specifies whether to store the credentials file in /opt/mesosphere or /etc/mesosphere/docker_credentials. A sysadmin cannot edit /opt/mesosphere directly."
 }
 
 variable "dcos_cluster_docker_credentials_write_to_etc" {
- default = ""
- description = "This parameter specifies whether to write a cluster credentials file."
+  default     = ""
+  description = "This parameter specifies whether to write a cluster credentials file."
 }
 
 variable "dcos_cluster_docker_credentials_enabled" {
- default = ""
- description = "This parameter specifies whether to pass the Mesos --docker_config option to Mesos."
+  default     = ""
+  description = "This parameter specifies whether to pass the Mesos --docker_config option to Mesos."
 }
 
 variable "dcos_cluster_docker_registry_enabled" {
- default = ""
- description = "This parameter specifies whether to pass the Mesos --docker_config option to Mesos."
+  default     = ""
+  description = "This parameter specifies whether to pass the Mesos --docker_config option to Mesos."
 }
 
 variable "dcos_cluster_docker_registry_url" {
- default = ""
- description = "This parameter specifies a custom URL that Mesos uses to pull Docker images from. If set, it will configure the Mesos’ --docker_registry flag to the specified URL. This changes the default URL Mesos uses for pulling Docker images. By default https://registry-1.docker.io is used."
+  default     = ""
+  description = "This parameter specifies a custom URL that Mesos uses to pull Docker images from. If set, it will configure the Mesos’ --docker_registry flag to the specified URL. This changes the default URL Mesos uses for pulling Docker images. By default https://registry-1.docker.io is used."
 }
 
 variable "dcos_enable_docker_gc" {
- default = ""
- description = "This parameter specifies whether to run the docker-gc script, a simple Docker container and image garbage collection script, once every hour to clean up stray Docker containers. You can configure the runtime behavior by using the /etc/ config. For more information, see the documentation"
+  default     = ""
+  description = "This parameter specifies whether to run the docker-gc script, a simple Docker container and image garbage collection script, once every hour to clean up stray Docker containers. You can configure the runtime behavior by using the /etc/ config. For more information, see the documentation"
 }
 
 variable "dcos_staged_package_storage_uri" {
- default = ""
- description = "This parameter specifies where to temporarily store DC/OS packages while they are being added. The value must be a file URL, for example, file:///var/lib/dcos/cosmos/staged-packages."
+  default     = ""
+  description = "This parameter specifies where to temporarily store DC/OS packages while they are being added. The value must be a file URL, for example, file:///var/lib/dcos/cosmos/staged-packages."
 }
 
 variable "dcos_package_storage_uri" {
- default = ""
- description = "This parameter specifies where to permanently store DC/OS packages. The value must be a file URL, for example, file:///var/lib/dcos/cosmos/packages."
+  default     = ""
+  description = "This parameter specifies where to permanently store DC/OS packages. The value must be a file URL, for example, file:///var/lib/dcos/cosmos/packages."
 }
-
 
 # Example value on how to configure rexray below
 # default = "{\"rexray\": {\"modules\": {\"default-docker\": {\"disabled\": true}, \"default-admin\": {\"host\": \"tcp://127.0.0.1:61003\"}}, \"loglevel\": \"info\"}}"
 
 variable "dcos_rexray_config" {
- default = ""
+  default = ""
 }
 
 variable "state" {
- default = "install"
- description = "Support installing or Upgrading DC/OS"
+  default     = "install"
+  description = "Support installing or Upgrading DC/OS"
 }
 
 variable "dcos_ip_detect_public_contents" {
- default = "\"'#!/bin/sh\\n\\n  set -o nounset -o errexit\\n\\n\\n  curl -fsSL http://169.254.169.254/latest/meta-data/public-ipv4\\n\\n   '\\n\""
- description = "Used for AWS to determine the public IP. DC/OS bug requires this variable instead of a file see https://jira.mesosphere.com/browse/DCOS_OSS-905 for more information."
+  default     = "\"'#!/bin/sh\\n\\n  set -o nounset -o errexit\\n\\n\\n  curl -fsSL http://169.254.169.254/latest/meta-data/public-ipv4\\n\\n   '\\n\""
+  description = "Used for AWS to determine the public IP. DC/OS bug requires this variable instead of a file see https://jira.mesosphere.com/browse/DCOS_OSS-905 for more information."
 }
 
 variable "kubernetes_cluster" {
- default = "kubernetes-cluster"
- description = "Kubernetes cluster tag"
+  default     = "kubernetes-cluster"
+  description = "Kubernetes cluster tag"
 }

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -7,7 +7,6 @@ variable "ssh_private_key_filename" {
   # cannot leave this empty as the file() interpolation will fail later on for the private_key local variable
   # https://github.com/hashicorp/terraform/issues/15605
   default = "/dev/null"
-
   description = "Path to file containing your ssh private key"
 }
 


### PR DESCRIPTION
These changes replace the `dcos_superuser_password_hash` variable with a new required variable `dcos_superuser_password` in `variables.tf`. It has no default, meaning that it _must_ be supplied for every `terraform apply` (since it's a plaintext password, an environment variable is probably the safest way to do so (`export TF_VAR_dcos_superuser_password=sosecret`)).

Additionally, a new local variable `dcos_superuser_password_hash` has been created in `main.tf` to hash the plaintext password, and this local is what will be used in the authentication process.

These changes also introduce some `terraform fmt` fixes.